### PR TITLE
Create parallel options

### DIFF
--- a/src/gzip.c
+++ b/src/gzip.c
@@ -193,7 +193,7 @@ static int part_nb;          /* number of parts in .gz file */
 static char *env;            /* contents of GZIP env variable */
 static char const *z_suffix; /* default suffix (can be set with --suffix) */
 static size_t z_len;         /* strlen(z_suffix) */
-       int threads = 0;      /* no parallel if deafults threads=0 */
+       int threads = 0;      /* no parallel if defaults threads=0 */
 
 /* The original timestamp (modification time).  If the original is
    unknown, TIME_STAMP.tv_nsec is negative.  If the original is


### PR DESCRIPTION
-j and --parallel take a positive integer argument for the number of threads to compress with in parallel. No implementation yet, but the options sets a ```threads``` global variable for use later.