### PR TITLE
Revert "added pure attribute to avoid error"

### DIFF
--- a/src/gzip.c
+++ b/src/gzip.c
@@ -1638,7 +1638,7 @@ crc_header_check (uch *magic)
   return 0;
 }
 
-__attribute__((pure)) static void
+static void
 watch_file_name_length (char* p)
 {
   if (p >= ofname+sizeof(ofname))


### PR DESCRIPTION
This reverts commit d56c4dcb0eeeaf73decf924aec15016b21ff6233.